### PR TITLE
BH1750: Prevent out-of-range values

### DIFF
--- a/src/supla/sensor/bh1750.h
+++ b/src/supla/sensor/bh1750.h
@@ -56,7 +56,7 @@ class Bh1750 : public GeneralPurposeMeasurement {
  protected:
   double getValue() override {
     double value = sensor.readLightLevel();
-    if (isnan(value) || value < 0) {
+    if (isnan(value) || value < 0 || value > 65'535) {
       invalidCounter++;
       if (invalidCounter < 4) {
         return lastValue;


### PR DESCRIPTION
## What does this PR change?

BH1750 is 16 bit sensor, max value is 65 535. PR adds limit for this max value to avoid out-of-range values when I2C communication produce incorrect values.

---

## Affected area

- [x] Arduino
- [ ] ESP-IDF
- [ ] extras/
- [ ] Documentation

---

## Notes

Optional.

---

## Checklist

- [x] Code builds for affected platforms
- [x] Code follows existing style and conventions
- [x] Documentation updated if needed
- [x] CLA accepted (requested automatically after opening the PR)
