### PR TITLE
Validate Fronius device type

### DIFF
--- a/extras/porting/linux/linux_yaml_config.cpp
+++ b/extras/porting/linux/linux_yaml_config.cpp
@@ -981,6 +981,13 @@ bool Supla::LinuxYamlConfig::addFronius(const YAML::Node& ch,
   if (ch["device_type"]) {
     paramCount++;
     deviceType = ch["device_type"].as<int>();
+    if (!Supla::PV::Fronius::isDeviceTypeSupported(deviceType)) {
+      SUPLA_LOG_ERROR(
+          "Channel[%d] config: unsupported Fronius device_type: %d",
+          channelNumber,
+          deviceType);
+      return false;
+    }
   }
 
   if (ch["ip"]) {  // mandatory

--- a/src/supla/pv/fronius.cpp
+++ b/src/supla/pv/fronius.cpp
@@ -33,9 +33,22 @@
 namespace Supla {
 namespace PV {
 
+bool Fronius::isDeviceTypeSupported(int deviceType) {
+  return deviceType == FRONIUS_SINGLE_PHASE_INVERTER ||
+         deviceType == FRONIUS_THREE_PHASE_INVERTER ||
+         deviceType == FRONIUS_THREE_PHASE_METER;
+}
+
 Fronius::Fronius(IPAddress ip, int port, int deviceId, int deviceType)
-    : ip(ip), port(port), deviceType(deviceType), deviceId(deviceId) {
-  if (deviceType == FRONIUS_SINGLE_PHASE_INVERTER) {
+    : ip(ip), port(port),
+      deviceType(isDeviceTypeSupported(deviceType)
+                     ? deviceType
+                     : FRONIUS_SINGLE_PHASE_INVERTER),
+      deviceId(deviceId) {
+  if (!isDeviceTypeSupported(deviceType)) {
+    SUPLA_LOG_ERROR("Unsupported Fronius device type: %d", deviceType);
+  }
+  if (this->deviceType == FRONIUS_SINGLE_PHASE_INVERTER) {
     extChannel.setFlag(SUPLA_CHANNEL_FLAG_PHASE2_UNSUPPORTED);
     extChannel.setFlag(SUPLA_CHANNEL_FLAG_PHASE3_UNSUPPORTED);
   }
@@ -433,13 +446,18 @@ bool Fronius::iterateConnected() {
 
         char idBuf[20];
         snprintf(idBuf, sizeof(idBuf), "%d", deviceId);
-        char buf[200];
+        char buf[200] = {};
         if (deviceType == FRONIUS_SINGLE_PHASE_INVERTER) {
           Fronius::getSinglePhaseInverterURL(buf, idBuf);
         } else if (deviceType == FRONIUS_THREE_PHASE_INVERTER) {
           Fronius::getThreePhaseInverterURL(buf, idBuf);
         } else if (deviceType == FRONIUS_THREE_PHASE_METER) {
           Fronius::getThreePhaseMeterURL(buf, idBuf);
+        } else {
+          SUPLA_LOG_ERROR("Unsupported Fronius device type: %d", deviceType);
+          client->stop();
+          dataFetchInProgress = false;
+          return Element::iterateConnected();
         }
         SUPLA_LOG_VERBOSE("Fronius query: %s", buf);
         client->println(buf);

--- a/src/supla/pv/fronius.h
+++ b/src/supla/pv/fronius.h
@@ -38,6 +38,7 @@ class Fronius : public Supla::Sensor::ElectricityMeter {
     int deviceId = 1,
     int deviceType = 0);
   ~Fronius();
+  static bool isDeviceTypeSupported(int deviceType);
   void readValuesFromDevice();
   void iterateAlways();
   bool iterateConnected();


### PR DESCRIPTION
### Motivation
- Prevent uninitialized stack data disclosure and crashes when an invalid Fronius `device_type` is supplied by configuration or direct construction. 

### Description
- Add `static bool Fronius::isDeviceTypeSupported(int)` to centralize allowed device types and use it to sanitize constructor input and log unsupported values. 
- In the `Fronius` constructor, coerce unsupported `deviceType` to a safe default and emit an error log when an unsupported value is provided. 
- Initialize the local HTTP request buffer (`char buf[200] = {}`) and add a defensive `else` branch in `iterateConnected()` that logs the error, stops the client, and aborts the send when the device type is unsupported. 
- Validate `device_type` read from the Linux YAML configuration and reject unsupported values before constructing the `Fronius` instance. 

### Testing
- Ran `git diff --check` with no issues reported. 
- Compiled `src/supla/pv/fronius.cpp` with `g++ -std=c++23 -DSUPLA_TEST -Iextras/test/doubles -Isrc -Iextras/porting/linux -c src/supla/pv/fronius.cpp` which succeeded. 
- Attempted to compile `extras/porting/linux/linux_yaml_config.cpp` but compilation failed due to missing `yaml-cpp` headers in the environment. 
- Attempted to run `cmake -S extras/test -B /tmp/supla-device-test-build` but FetchContent failed to clone GitHub dependency (`https://github.com/nlohmann/json.git`) due to network restrictions (CONNECT 403).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69fb8124624c8320889a60d4315bb940)