### PR TITLE
Prevent null dereference in PwmFrequencyParameters::handleResponse

### DIFF
--- a/src/supla/network/html/pwm_frequency_parameters.cpp
+++ b/src/supla/network/html/pwm_frequency_parameters.cpp
@@ -75,6 +75,10 @@ void PwmFrequencyParameters::send(Supla::WebSender* sender) {
 bool PwmFrequencyParameters::handleResponse(const char* key,
                                             const char* value) {
   if (strcmp(key, Supla::ConfigTag::PwmFrequencyTag) == 0) {
+    if (!rgbCct) {
+      return false;
+    }
+
     uint32_t pwmFrequency = stringToUInt(value);
     // setPwmFrequency() will apply validation and will correct pwmFrequency
     // to allowed value


### PR DESCRIPTION
### Motivation
- The `PwmFrequencyParameters` HTML element may be created without a backing `LightingPwmBase` (`rgbCct` can be null), and while `send()` already tolerated a null `rgbCct`, `handleResponse()` unconditionally dereferenced it for the `pwm_freq` POST parameter which can cause a null pointer dereference and device crash.

### Description
- Add a null guard in `PwmFrequencyParameters::handleResponse` (in `src/supla/network/html/pwm_frequency_parameters.cpp`) that returns `false` when `rgbCct` is null so the handler does not parse or apply a submitted `pwm_freq` value, preserving the existing null-safe rendering behavior.

### Testing
- Ran `./check_cpplint.sh` (passed), a syntax-only compile with `g++ -std=c++17 -Isrc -fsyntax-only src/supla/network/html/pwm_frequency_parameters.cpp` (passed), and attempted `cmake -S . -B /tmp/supla-device-build` which failed in this isolated invocation due to the top-level CMake expecting project targets not present in a standalone configure.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69fb825d0a688320b255e226a758724d)