### PR TITLE
Fix OTA recovery certificate skip persistence

### DIFF
--- a/extras/test/SwUpdateTests/sw_update_tests.cpp
+++ b/extras/test/SwUpdateTests/sw_update_tests.cpp
@@ -326,6 +326,10 @@ TEST_F(SwUpdateTests, FirmwareCheckAndNormalUpdate) {
   Supla::messageReceived(nullptr, 0, 0, srpcLayer, 28);
   moveTime(10);
 
+  // A stale recovery-mode flag must not disable certificate validation for
+  // cloud-triggered firmware updates.
+  EXPECT_CALL(cfg, isSwUpdateSkipCert()).WillRepeatedly(Return(true));
+
   // authorized and supported, start update, new version not available
   EXPECT_CALL(srpc, srpc_getdata(_, _, _))
       .WillOnce([&calcfgRequest](
@@ -357,6 +361,7 @@ TEST_F(SwUpdateTests, FirmwareCheckAndNormalUpdate) {
       .WillOnce([this]() {
         swUpdate.setNewVersion("1.2.3");
         EXPECT_FALSE(swUpdate.isSecurityOnly());
+        EXPECT_FALSE(swUpdate.isSkipCertOnFacade());
         swUpdate.setFinished();
       });
 
@@ -842,11 +847,16 @@ TEST_F(SwUpdateTests, AutomaticUpdateTriggeredInternallySecurityOnly) {
 //  EXPECT_CALL(cfg, setSwUpdateBeta(false)).Times(1);
   EXPECT_CALL(cfg, commit()).Times(AtLeast(1));
 
+  // A stale recovery-mode flag must not disable certificate validation for
+  // periodic automatic OTA checks.
+  EXPECT_CALL(cfg, isSwUpdateSkipCert()).WillRepeatedly(Return(true));
+
   EXPECT_CALL(swUpdate, iterate())
       .WillOnce([this]() {
         swUpdate.setNewVersion("1.2.3");
         swUpdate.setFinished();
         EXPECT_TRUE(swUpdate.isSecurityOnlyOnFacade());
+        EXPECT_FALSE(swUpdate.isSkipCertOnFacade());
       });
   moveTime(5);
   time.advance(Supla::AutomaticOtaCheckInterval);

--- a/extras/test/doubles/sw_update_mock.cpp
+++ b/extras/test/doubles/sw_update_mock.cpp
@@ -52,6 +52,10 @@ class SwUpdateFacade : public Supla::Device::SwUpdate {
     snprintf(newVersion, strlen(version) + 1, "%s", version);
   }
 
+  bool isSkipCert() const {
+    return skipCert;
+  }
+
   SwUpdateMock *mock;
 };
 
@@ -83,4 +87,8 @@ void SwUpdateMock::setNewVersion(const char *version) {
 
 bool SwUpdateMock::isSecurityOnlyOnFacade() {
   return facade->isSecurityOnly();
+}
+
+bool SwUpdateMock::isSkipCertOnFacade() {
+  return facade->isSkipCert();
 }

--- a/extras/test/doubles/sw_update_mock.h
+++ b/extras/test/doubles/sw_update_mock.h
@@ -38,6 +38,7 @@ class SwUpdateMock : public Supla::Device::SwUpdate {
   void setFacade(SwUpdateFacade *facade) { this->facade = facade; }
   void setNewVersion(const char *version);
   bool isSecurityOnlyOnFacade();
+  bool isSkipCertOnFacade();
 };
 
 

--- a/src/SuplaDevice.cpp
+++ b/src/SuplaDevice.cpp
@@ -599,6 +599,7 @@ void SuplaDeviceClass::iterate(void) {
         deviceMode = Supla::DEVICE_MODE_NORMAL;
         if (cfg) {
           cfg->setDeviceMode(Supla::DEVICE_MODE_NORMAL);
+          cfg->setSwUpdateSkipCert(false);
           cfg->setSwUpdateBeta(false);
           cfg->commit();
         }
@@ -679,8 +680,11 @@ bool SuplaDeviceClass::initSwUpdateInstance(Supla::SwUpdateMode mode,
     if (cfg->isSwUpdateBeta()) {
       swUpdate->useBeta();
     }
-    if (cfg->isSwUpdateSkipCert()) {
-      // Recovery-only fallback; the OTA flow clears this after use.
+    if (deviceMode == Supla::DEVICE_MODE_SW_UPDATE &&
+        cfg->isSwUpdateSkipCert()) {
+      // Recovery-only fallback for a locally requested SW update.
+      // Automatic and remotely triggered OTA checks must keep certificate
+      // verification enabled even if an old recovery flag remains in storage.
       swUpdate->setSkipCert();
     }
   }
@@ -748,6 +752,11 @@ void SuplaDeviceClass::iterateSwUpdate() {
       //      }
     } else if (swUpdate->isFinished()) {
       SUPLA_LOG_INFO("Finished SW update, restarting...");
+      auto cfg = Supla::Storage::ConfigInstance();
+      if (cfg) {
+        cfg->setSwUpdateSkipCert(false);
+        cfg->commit();
+      }
       delete swUpdate;
       swUpdate = nullptr;
       scheduleSoftRestart();


### PR DESCRIPTION
### Motivation
- A local "one-time recovery" option persisted `swUpdNoCert=true` and was reused by periodic and cloud-triggered OTA checks, disabling server certificate validation beyond the intended recovery use and enabling MITM attacks. 

### Description
- Restrict runtime `skipCert` propagation so the `SwUpdate` instance only inherits the recovery flag when `deviceMode == Supla::DEVICE_MODE_SW_UPDATE`. 
- Clear the persisted `swUpdNoCert` flag when leaving local SW update mode by calling `cfg->setSwUpdateSkipCert(false)` in the SW update exit path in `src/SuplaDevice.cpp`. 
- Also clear and commit `swUpdNoCert` on update completion before scheduling the restart in `src/SuplaDevice.cpp`. 
- Add test coverage and a mock accessor so tests assert that a stale persisted recovery flag does not disable certificate verification for cloud-triggered or periodic automatic OTA checks (`extras/test/SwUpdateTests/sw_update_tests.cpp` and `extras/test/doubles/sw_update_mock.*`).

### Testing
- Ran `git diff --check` which passed without whitespace errors. 
- Attempted to configure the test build with `cmake -S extras/test -B /tmp/supla-test-build -DCMAKE_BUILD_TYPE=Debug`, but the environment failed to fetch external dependencies (FetchContent attempted to clone `https://github.com/nlohmann/json.git` and returned `CONNECT tunnel failed, response 403`), so the test build could not be completed here. 
- Unit test sources were updated to validate the fix (new expectations added to `extras/test/SwUpdateTests/sw_update_tests.cpp` and a new `isSkipCertOnFacade` accessor in `extras/test/doubles/sw_update_mock.*`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69fb90d87c9c8320abf3e6e986fed77e)