### PR TITLE
Secure sd4linux Docker TLS defaults

### DIFF
--- a/extras/docker/supla_device_4_linux/conf/supla-device.yaml
+++ b/extras/docker/supla_device_4_linux/conf/supla-device.yaml
@@ -1,7 +1,7 @@
 name: My fancy device
 log_level: debug
 state_files_path: "./auth"
-security_level: 2 # disable certificate verification
+security_level: 0 # verify server certificate with SUPLA CA
 
 supla:
   server: supla.gorale

--- a/extras/docker/supla_device_4_linux/readme.md
+++ b/extras/docker/supla_device_4_linux/readme.md
@@ -1,6 +1,7 @@
 # Readme
 This docker image contains a `supla-device-4-linux` instance. \
 There is a sample configuration file for this instance in the local `conf` directory. It should be adapted to your needs by configuring the necessary channels, connection to the Supla server and the name of the device that this instance will represent.\
+By default, the sample configuration verifies the SUPLA server certificate; do not change `security_level` to `2` unless you explicitly accept running without server certificate validation.\
 The `data` directory should contain files from which channels with a File source type will read data sent to the Supla server.\
 In the `auth` directory, the instance will create a file with the GUID and Auth required to identify the device on the Supla server and a log with the latest status as well as a file with data transferred from the Supla server.
 ## Build and run without `docker compose`


### PR DESCRIPTION
### Motivation
- The sd4linux Docker example previously shipped with `security_level: 2`, which disables SUPLA TLS certificate verification and creates a high-risk default for users following the example.

### Description
- Change `extras/docker/supla_device_4_linux/conf/supla-device.yaml` to `security_level: 0` so the SUPLA server certificate is verified by default.
- Add guidance to `extras/docker/supla_device_4_linux/readme.md` warning that `security_level: 2` disables certificate validation and should only be used when explicitly accepted.

### Testing
- Verified the Docker sample config contains `security_level: 0` using a short Python check that inspects `extras/docker/supla_device_4_linux/conf/supla-device.yaml` and asserts the value is `0`.
- Searched the sd4linux docker directory with `rg` to confirm there are no remaining occurrences of `security_level: 2` or the insecure comment, and `git diff --check` reported no problems.
- Attempted a local `cmake` build of the example, but configuration could not complete in this environment because the `yaml-cpp` development package/config is unavailable, so a full build was not validated here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69fbada6d9d883209b4496c775676437)