### PR TITLE
Guard AVR-specific Ethernet drivers with `ARDUINO_ARCH_AVR`

### DIFF
--- a/src/supla/network/ENC28J60.h
+++ b/src/supla/network/ENC28J60.h
@@ -19,6 +19,7 @@
 #ifndef SRC_SUPLA_NETWORK_ENC28J60_H_
 #define SRC_SUPLA_NETWORK_ENC28J60_H_
 
+#ifdef ARDUINO_ARCH_AVR
 #include <Arduino.h>
 #include <EthernetENC.h>
 
@@ -67,5 +68,7 @@ class ENC28J60 : public Supla::Network {
 };
 
 };  // namespace Supla
+
+#endif  // ARDUINO_ARCH_AVR
 
 #endif  // SRC_SUPLA_NETWORK_ENC28J60_H_

--- a/src/supla/network/ethernet_shield.h
+++ b/src/supla/network/ethernet_shield.h
@@ -19,6 +19,7 @@
 #ifndef SRC_SUPLA_NETWORK_ETHERNET_SHIELD_H_
 #define SRC_SUPLA_NETWORK_ETHERNET_SHIELD_H_
 
+#ifdef ARDUINO_ARCH_AVR
 #include <Arduino.h>
 #include <Ethernet.h>
 
@@ -86,5 +87,7 @@ class EthernetShield : public Supla::Network {
 };
 
 };  // namespace Supla
+
+#endif  // ARDUINO_ARCH_AVR
 
 #endif  // SRC_SUPLA_NETWORK_ETHERNET_SHIELD_H_


### PR DESCRIPTION
### Motivation
- Restrict inclusion and definitions of `ENC28J60` and `EthernetShield` to AVR Arduino builds to avoid compilation errors on non-AVR platforms.

### Description
- Add `#ifdef ARDUINO_ARCH_AVR` / `#endif` guards around Arduino includes and the `Supla::ENC28J60` and `Supla::EthernetShield` class definitions in `ENC28J60.h` and `ethernet_shield.h`.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69fe2c7965dc8320963e83399c3565b0)