### PR TITLE
Fix roller shutter calibration with unknown position

### DIFF
--- a/extras/test/RollerShutterTests/roller_shutter_tests.cpp
+++ b/extras/test/RollerShutterTests/roller_shutter_tests.cpp
@@ -648,6 +648,60 @@ TEST_F(RollerShutterFixture, movementByServerTests) {
   EXPECT_EQ(Supla::RegisterDevice::getChannelValuePtr(0)[0], 22);
 }
 
+TEST_F(RollerShutterFixture, loadedUnknownPositionIsNotCalibrated) {
+  StorageMock storage;
+  Supla::Control::RollerShutter rs(gpioUp, gpioDown);
+
+  storage.defaultInitialization(9);
+  EXPECT_CALL(storage, scheduleSave(_, 1000)).Times(AtLeast(0));
+  EXPECT_CALL(storage, writeStorage(8, _, 7)).WillRepeatedly(Return(7));
+  EXPECT_CALL(storage, commit()).WillRepeatedly(Return());
+
+  EXPECT_CALL(
+      storage, readStorage(_, _, /* sizeof(RollerShutterStateData) */ 9, _))
+      .WillOnce([](uint32_t, unsigned char *data, int, bool) {
+        RollerShutterStateDataTests rsData = {.closingTimeMs = 10000,
+                                              .openingTimeMs = 10000,
+                                              .currentPosition =
+                                                  UNKNOWN_POSITION};
+        EXPECT_EQ(9, sizeof(rsData));
+        memcpy(data, &rsData, sizeof(RollerShutterStateDataTests));
+        return 9;
+      });
+
+  {
+    ::testing::InSequence seq;
+    EXPECT_CALL(ioMock, digitalWrite(gpioUp, 0));
+    EXPECT_CALL(ioMock, pinMode(gpioUp, OUTPUT));
+    EXPECT_CALL(ioMock, digitalWrite(gpioDown, 0));
+    EXPECT_CALL(ioMock, pinMode(gpioDown, OUTPUT));
+
+    // An absolute open target with unknown current position must open, not
+    // close due to target-position arithmetic against UNKNOWN_POSITION.
+    EXPECT_CALL(ioMock, digitalWrite(gpioDown, 0));
+    EXPECT_CALL(ioMock, digitalWrite(gpioUp, 1));
+  }
+
+  Supla::Storage::LoadStateStorage();
+  rs.onInit();
+
+  EXPECT_EQ(rs.getCurrentPosition(), UNKNOWN_POSITION);
+  EXPECT_FALSE(rs.isCalibrated());
+
+  TSD_SuplaChannelNewValue newValueFromServer = {};
+  auto value =
+      reinterpret_cast<TCSD_RollerShutterValue *>(newValueFromServer.value);
+  newValueFromServer.DurationMS = (100 << 16) | 100;
+  newValueFromServer.ChannelNumber = 0;
+  value->position = 10;  // absolute open target (0%)
+
+  rs.handleNewValueFromServer(&newValueFromServer);
+  rs.onTimer();
+
+  EXPECT_EQ(rs.getCurrentDirection(),
+            static_cast<int>(Supla::Control::Directions::UP_DIR));
+}
+
 TEST_F(RollerShutterFixture, onLoadStateClampsUnsafeTimes) {
   StorageMock storage;
   Supla::Control::RollerShutter rs(gpioUp, gpioDown);

--- a/src/supla/control/roller_shutter_interface.cpp
+++ b/src/supla/control/roller_shutter_interface.cpp
@@ -565,11 +565,11 @@ bool RollerShutterInterface::isCalibrationRequested() const {
 }
 
 bool RollerShutterInterface::isCalibrated() const {
-  if (isTimeSettingAvailable()) {
-    return !getCalibrate() && openingTimeMs != 0 && closingTimeMs != 0;
-  } else {
-    return !getCalibrate() && currentPosition != UNKNOWN_POSITION;
+  if (getCalibrate() || getCurrentPosition() == UNKNOWN_POSITION) {
+    return false;
   }
+  return !isTimeSettingAvailable() ||
+         (openingTimeMs != 0 && closingTimeMs != 0);
 }
 
 bool RollerShutterInterface::isCalibrationInProgress() const {


### PR DESCRIPTION
### Motivation
- A refactor changed the default calibration state so a restored `UNKNOWN_POSITION` could be treated as calibrated when opening/closing times exist, causing absolute OPEN commands to compute movement against `-1` and trigger the wrong motor direction.
- The intent is to ensure a roller shutter restored with unknown position is considered not calibrated so commands that rely on a known position behave safely.

### Description
- Update `RollerShutterInterface::isCalibrated()` to return `false` when `getCalibrate()` is set or `getCurrentPosition() == UNKNOWN_POSITION`, and only consider time-based calibration when a known position exists; the change is in `src/supla/control/roller_shutter_interface.cpp`.
- Add a regression unit test `loadedUnknownPositionIsNotCalibrated` to `extras/test/RollerShutterTests/roller_shutter_tests.cpp` that restores a state with `UNKNOWN_POSITION` and asserts the device remains uncalibrated and an absolute open target starts opening (checks `getCurrentDirection()` is `UP_DIR`).
- Keep behavior for time-setting vs position-based channels consistent by guarding calibration checks with the unknown-position condition.

### Testing
- Ran `git diff --check` which reported no issues.
- Attempted to run the test build via `cmake -S extras/test -B /tmp/supla-device-test-build` but it failed during FetchContent cloning of `https://github.com/nlohmann/json.git` (CONNECT tunnel HTTP 403), so the test binary could not be built in this environment.
- Added the unit test as coverage for the regression; it will run in CI or a developer environment where FetchContent dependencies can be retrieved.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a085e6f67f483209e7c38e8e865bd44)