### PR TITLE
Redact MQTT credentials in configuration logs

### DIFF
--- a/src/supla/protocol/mqtt.cpp
+++ b/src/supla/protocol/mqtt.cpp
@@ -153,10 +153,10 @@ bool Supla::Protocol::Mqtt::onLoadConfig() {
     enabled = false;
   }
 
-  SUPLA_LOG_INFO(
+  SUPLA_LOG_DEBUG(
       "MQTT: Protocol %s, broker \"%s\", port %d, TLS %s, retain %s, QoS %d, "
-      "auth %s,"
-      "user \"%s\", password %s",
+      "auth %s, "
+      "user %s, password %s",
       enabled ? "enabled" : "disabled",
       server,
       port,
@@ -164,8 +164,8 @@ bool Supla::Protocol::Mqtt::onLoadConfig() {
       retainCfg ? "enabled" : "disabled",
       qosCfg,
       useAuth ? "enabled" : "disabled",
-      user,
-      strlen(password) > 0 ? "****" : "NOT SET");
+      strlen(user) > 0 ? "SET" : "NOT SET",
+      strlen(password) > 0 ? "SET" : "NOT SET");
 
   return configComplete;
 }


### PR DESCRIPTION
### Motivation
- Prevent accidental exposure of MQTT authentication identifiers by moving the configuration dump out of INFO logs and avoiding printing the plaintext MQTT username.

### Description
- Change the MQTT configuration log in `Supla::Protocol::Mqtt::onLoadConfig()` from `SUPLA_LOG_INFO` to `SUPLA_LOG_DEBUG` in `src/supla/protocol/mqtt.cpp`.
- Stop printing the plaintext `user` and masked password, and instead log credential presence as `SET` / `NOT SET` using `strlen(user)`/`strlen(password)` checks.

### Testing
- Ran a syntax-only compile with `c++ -std=c++23 -DSUPLA_TEST -Iextras/test/doubles -Isrc -Iextras/porting/linux -fsyntax-only src/supla/protocol/mqtt.cpp`, which succeeded.
- Ran `git diff --check`, which reported no issues.
- Attempted full test build with `cmake -S extras/test -B /tmp/supla-device-tests && cmake --build /tmp/supla-device-tests --target supladevicetests -j2`, but the build was blocked because `FetchContent` failed to clone `nlohmann/json` due to a network error (CONNECT tunnel failed, 403).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a085a3d75c88320a701173a3c168cf2)