### PR TITLE
Invoke generated HVAC onchange handlers by appending ()

### DIFF
--- a/src/supla/network/html/hvac_parameters.cpp
+++ b/src/supla/network/html/hvac_parameters.cpp
@@ -398,16 +398,18 @@ void HvacParameters::send(Supla::WebSender* sender) {
   if (!hvac->parameterFlags.AuxMinMaxSetpointEnabledHidden) {
     hvac->generateKey(key, "aux_ctrl");
     char auxChangeFn[48] = {};
+    char auxOnChange[52] = {};
     snprintf(auxChangeFn,
              sizeof(auxChangeFn),
              "auxSetpointEnabledChange_%d",
              hvac->getChannelNumber());
+    snprintf(auxOnChange, sizeof(auxOnChange), "%s()", auxChangeFn);
     emitSwitchField(sender,
                     key,
                     "Enable auxiliary min. and max. setpoints",
                     hvac->isAuxMinMaxSetpointEnabled(),
                     hvac->parameterFlags.AuxMinMaxSetpointEnabledReadonly,
-                    auxChangeFn);
+                    auxOnChange);
 
     sender->send(
         "<script>"
@@ -458,17 +460,20 @@ void HvacParameters::send(Supla::WebSender* sender) {
     sender->tag("h2").body("Anti freeze and overheat protection");
     hvac->generateKey(key, "anti_freeze");
     char antiFreezeChangeFn[48] = {};
+    char antiFreezeOnChange[52] = {};
     snprintf(antiFreezeChangeFn,
              sizeof(antiFreezeChangeFn),
              "antiFreezeAndHeatProtectionChange_%d",
              hvac->getChannelNumber());
+    snprintf(
+        antiFreezeOnChange, sizeof(antiFreezeOnChange), "%s()", antiFreezeChangeFn);
     emitSwitchField(
         sender,
         key,
         "Enable anti-freeze and overheat protection",
         hvac->isAntiFreezeAndHeatProtectionEnabled(),
         hvac->parameterFlags.AntiFreezeAndOverheatProtectionEnabledReadonly,
-        antiFreezeChangeFn);
+        antiFreezeOnChange);
 
     sender->send(
         "<script>"


### PR DESCRIPTION
### Motivation

- Fix a UI regression where generated per-channel handler names (e.g. `auxSetpointEnabledChange_<n>`) were written into `onchange` attributes as bare identifiers so the handler was not invoked in the browser. 
- The intent is to preserve the unique per-channel function names while restoring the original invocation behavior so toggling checkboxes shows/hides the related settings boxes.

### Description

- Construct executable handler strings by appending `()` to generated function names and pass those strings to `emitSwitchField` instead of the bare function name for the auxiliary setpoint toggle. 
- Apply the same fix for the anti-freeze/overheat toggle by generating `antiFreezeOnChange` as `"antiFreezeAndHeatProtectionChange_<n>()"` and passing it to `emitSwitchField`.
- Preservation: the script that declares the per-channel functions is left intact and still emits `function functionName_<n>(){...}` so uniqueness is preserved.

### Testing

- No full automated test suite was run in this environment; automated source checks were performed and succeeded using `rg` to verify the new symbols and `nl` to inspect the modified lines. 
- The source now contains `auxOnChange` and `antiFreezeOnChange` and passes `"functionName()"` strings to `emitSwitchField` as intended. 
- Manual static verification confirmed the emitted `onchange` will now invoke the generated functions (`functionName()`), which restores the expected UI behavior.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a0dd9e5c5f48320baac9abfc74e0c5f)